### PR TITLE
[ICE-101] bump apiVersion

### DIFF
--- a/.github/workflows/push_to_test_app_catalog.yaml
+++ b/.github/workflows/push_to_test_app_catalog.yaml
@@ -1,0 +1,16 @@
+name: 'Push to ICE Cluster Test Catalog'
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+jobs:
+  push_to_app_catalog:
+    uses: giantswarm/app-build-suite/.github/workflows/push-to-app-catalog.yaml@v1.1.2
+    with:
+      app_catalog: ice-cluster-test-catalog
+      chart: cluster-openstack
+      organization: thg-ice
+    secrets:
+      envPAT: ${{ secrets.WORKFLOW_WRITE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2] - 2023-03-29
+
+### Changed
+
+- Changes the CAPO apiVersion to v1alpha6.
+- Add Helm annotations to keep OpenStackCluster and KubeadmControlPlane when deleting.
+
 ## [0.18.1] - 2023-03-15
 
 ### Added
@@ -259,7 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation.
 
-[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.1...HEAD
+[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.2...HEAD
+[0.18.2]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.0...v0.18.1
 [0.17.1]: https://github.com/giantswarm/cluster-openstack/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/giantswarm/cluster-openstack/compare/v0.16.1...v0.17.0

--- a/helm/cluster-openstack/ci/ci-values.yaml
+++ b/helm/cluster-openstack/ci/ci-values.yaml
@@ -7,7 +7,7 @@ dnsNameservers:
 - 1.1.1.1
 - 8.8.8.8
 externalNetworkID: external-network-id
-kubernetesVersion: 1.20.9
+kubernetesVersion: 1.24.9
 managementCluster: testmc
 nodeCIDR: 10.6.0.0/24
 organization: testorg

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "infrastructureApiVersion" -}}
-infrastructure.cluster.x-k8s.io/v1alpha5
+infrastructure.cluster.x-k8s.io/v1alpha6
 {{- end -}}
 
 {{/*

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -5,6 +5,9 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    # Let Cluster API clean this resource up.
+    helm.sh/resource-policy: keep
 spec:
   kubeadmConfigSpec:
     {{- if .Values.ignition.enable }}

--- a/helm/cluster-openstack/templates/openstack_cluster.yaml
+++ b/helm/cluster-openstack/templates/openstack_cluster.yaml
@@ -5,6 +5,9 @@ metadata:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    # Let Cluster API clean this resource up.
+    helm.sh/resource-policy: keep
 spec:
   {{- if .Values.managementCluster }}
   tags:


### PR DESCRIPTION
This PR:

- Changes the default `apiVersion` to `v1alpha6`
- Add Helm annotations to keep OpenStackCluster and KubeadmControlPlane when deleting.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
