### PR TITLE
[ICE-288] allow configuring allowedCidrs

### DIFF
--- a/helm/cluster-openstack/templates/openstack_cluster.yaml
+++ b/helm/cluster-openstack/templates/openstack_cluster.yaml
@@ -25,6 +25,10 @@ spec:
     kind: Secret
   apiServerLoadBalancer:
     enabled: true
+    allowedCidrs:
+    {{- range .Values.apiServerLoadBalancer.allowedCidrs }}
+    - {{ . | quote }}
+    {{- end }}
   managedSecurityGroups: true
   {{- if .Values.nodeCIDR }}
   nodeCidr: {{ .Values.nodeCIDR | quote }}
@@ -54,7 +58,7 @@ spec:
           name: {{ .Values.networkName }}
         subnets:
         - filter:
-            name: {{ .Values.subnetName }} 
+            name: {{ .Values.subnetName }}
       {{- end }}
       {{- if .Values.bastion.bootFromVolume }}
       rootVolume:

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -17,6 +17,8 @@ nodeCIDR: ""  # The OpenStack Subnet to be created.
 externalNetworkID: ""  # UUID of external network (optional unless there are multiple external networks).
 networkName: ""  # Existing network name. Ignored when nodeCIDR is set.
 subnetName: ""  # Existing subnet name. Ignored when nodeCIDR is set.
+apiServerLoadBalancer:
+  allowedCidrs: []  # Allowed CIDR ranges for the API Server LB (optional, leave blank to allow all).
 
 sshTrustedUserCAKeys:
   # Taken from https://vault.operations.giantswarm.io/v1/ssh/public_key


### PR DESCRIPTION
This PR:

- allows configuring `spec.apiServerLoadBalancer.allowedCidrs` field on `OpenStackCluster`.

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
