### PR TITLE
[ICE-294] expose OpenStackMachineTemplate spec.volumeType field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.18.4] - 2023-04-03
+## [0.18.4] - 2023-04-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.4] - 2023-04-03
+
+### Added
+
+- A stanza to configure the OpenStackMachineTemplate volumeType.
+
 ## [0.18.3] - 2023-03-30
 
 ### Added
@@ -272,7 +278,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation.
 
-[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.3...HEAD
+[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.4...HEAD
+[0.18.4]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.3...v0.18.4
 [0.18.3]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.2...v0.18.3
 [0.18.2]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.0...v0.18.1

--- a/helm/cluster-openstack/ci/ci-values.yaml
+++ b/helm/cluster-openstack/ci/ci-values.yaml
@@ -31,6 +31,7 @@ controlPlane:
   image: control-plane-image
   replicas: 3
   bootFromVolume: true
+  volumeType: control-plane-volume-type
 
 nodeClasses:
   default:

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -175,6 +175,9 @@ networks:
 {{- if .currentClass.bootFromVolume }}
 rootVolume:
   diskSize: {{ .currentClass.diskSize }}
+  {{- if .currentClass.volumeType }}
+  volumeType: {{ .currentClass.volumeType | quote }}
+  {{- end }}
 {{- end }}
 image: {{ .currentClass.image | quote }}
 {{- end -}}

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -121,6 +121,9 @@
                 "resourceRatio" : {
                     "minimum": 2,
                     "type": "integer"
+                },
+                "volumeType": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -60,6 +60,7 @@ nodeClasses: {}  # Class definitions for worker node pools. The "name" of the cl
   #   diskSize: 50
   #   flavor: n1.medium
   #   image: ubuntu-2004-kube-v1.22.9
+  #   volumeType: my-type
 
 nodePools: {}  # Node pools that should exist for the cluster. Each node pool must refer to a class defined in nodeClasses above. Example:
   # us-dc-1:


### PR DESCRIPTION
This PR:

- Adds a stanza to configure the OpenStackMachineTemplate volumeType

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
