### PR TITLE
[ICE-311] use registry.k8s.io for etcd image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.5] - 2023-04-06
+
+### Changed
+
+- Set the etcd image repository to registry.k8s.io.
+- Bump etcd version to 3.5.6.
+
 ## [0.18.4] - 2023-04-05
 
 ### Added

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -51,7 +51,7 @@ controlPlane:
   bootFromVolume: false  # If true, machines will use a persistent root volume instead of an ephemeral volume.
   etcd:
     imageRepository: "registry.k8s.io"
-    imageTag: "3.5.6"
+    imageTag: "3.5.6-0"
   resourceRatio: 8  # Ratio between node resources and apiserver resource requests.
 
 nodeClasses: {}  # Class definitions for worker node pools. The "name" of the class is the key of the object. The properties may include "diskSize", "flavor", "image", and "bootFromVolume" as defined for control plane and bastion above. Example:

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -50,8 +50,8 @@ controlPlane:
   replicas: 0  # Number of replicas in control plane. Should be an odd number.
   bootFromVolume: false  # If true, machines will use a persistent root volume instead of an ephemeral volume.
   etcd:
-    imageRepository: "giantswarm"
-    imageTag: 3.5.4-0-k8s
+    imageRepository: "registry.k8s.io"
+    imageTag: "3.5.6"
   resourceRatio: 8  # Ratio between node resources and apiserver resource requests.
 
 nodeClasses: {}  # Class definitions for worker node pools. The "name" of the class is the key of the object. The properties may include "diskSize", "flavor", "image", and "bootFromVolume" as defined for control plane and bastion above. Example:


### PR DESCRIPTION
This PR:

- Set the etcd image repository to registry.k8s.io.
- Bump etcd version to 3.5.6.

### Testing

- [x] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [x] Make sure `values.yaml` is valid.
