### PR TITLE
dont delete old KubeadmConfigTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.6] - 2023-04-20
+
+### Changed
+
+- Add Helm annotations to keep KubeadmConfigTemplate when deleting.
+
 ## [0.18.5] - 2023-04-06
 
 ### Changed
@@ -285,7 +291,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial implementation.
 
-[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.4...HEAD
+[Unreleased]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.6...HEAD
+[0.18.6]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.5...v0.18.6
+[0.18.5]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.4...v0.18.5
 [0.18.4]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.3...v0.18.4
 [0.18.3]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.2...v0.18.3
 [0.18.2]: https://github.com/thg-ice/cluster-openstack/compare/v0.18.1...v0.18.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add Helm annotations to keep KubeadmConfigTemplate when deleting.
+- Add Helm annotations to keep KubeadmConfigTemplate and OpenStackMachineTemplate when deleting.
 
 ## [0.18.5] - 2023-04-06
 

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -3,6 +3,9 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  annotations:
+    # Let Cluster API clean this resource up.
+    helm.sh/resource-policy: keep
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{- include "kubeadmConfigTemplateRevision" (merge (dict "pool" $value) $) }}

--- a/helm/cluster-openstack/templates/kubeadm_config_template.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_config_template.yaml
@@ -3,11 +3,11 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
+  labels:
+    {{- include "labels.common" $ | nindent 4 }}
   annotations:
     # Let Cluster API clean this resource up.
     helm.sh/resource-policy: keep
-  labels:
-    {{- include "labels.common" $ | nindent 4 }}
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{- include "kubeadmConfigTemplateRevision" (merge (dict "pool" $value) $) }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/helm/cluster-openstack/templates/openstack_machine_template.yaml
+++ b/helm/cluster-openstack/templates/openstack_machine_template.yaml
@@ -6,6 +6,9 @@ kind: OpenStackMachineTemplate
 metadata:
   labels:
     {{- include "labels.common" $ | nindent 4 }}
+  annotations:
+    # Let Cluster API clean this resource up.
+    helm.sh/resource-policy: keep
   name: {{ include "resource.default.name" $ }}-{{ $name }}-{{ include "osmtRevision" $c }}
   namespace: {{ $.Release.Namespace }}
 spec:


### PR DESCRIPTION
This PR:

- Add Helm annotations to keep KubeadmConfigTemplate when deleting.

### Testing

- [ ] Fresh install works.
- [x] Upgrade from previous version works.

### Checklist

- [x] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
