### PR TITLE
remove deprecated flag logtostderr

### DIFF
--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -39,7 +39,6 @@ spec:
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           feature-gates: {{ .Values.apiServer.featureGates }}
           kubelet-preferred-address-types: "InternalIP"
-          logtostderr: "true"
           {{- if .Values.oidc.issuerUrl }}
           {{- with .Values.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
@@ -70,7 +69,6 @@ spec:
           bind-address: "0.0.0.0"
           cloud-provider: external
           feature-gates: {{ .Values.controllerManager.featureGates }}
-          logtostderr: "true"
           profiling: "false"
       etcd:
         local:


### PR DESCRIPTION
This PR:

- removes deprecated command line argument from the control plane, see https://kubernetes.io/docs/concepts/cluster-administration/system-logs/#klog
### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
