### PR TITLE
removing featuregate for ExpandPersistentVolumes as it's deprecated

### DIFF
--- a/helm/cluster-openstack/files/kubelet-args
+++ b/helm/cluster-openstack/files/kubelet-args
@@ -1,5 +1,4 @@
 cloud-provider: external
-feature-gates: "ExpandPersistentVolumes=true"
 eviction-hard : "memory.available<200Mi"
 eviction-max-pod-grace-period: "60"
 eviction-soft: "memory.available<500Mi"


### PR DESCRIPTION
This PR:

- Remove the ExpandPersistentVolumes featuregate as it's deprecated: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
