### PR TITLE
Certificates rollout before expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Rollout machines and certificates 14 days prior to expiry.
+- Ability to set machines and certificates rollout prior to expiry.
 
 ## [0.18.7] - 2024-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.8] - 2024-03-08
+
+## Changed
+
+- Rollout machines and certificates 14 days prior to expiry.
+
 ## [0.18.7] - 2024-02-14
 
 ### Changed

--- a/helm/cluster-openstack/Chart.yaml
+++ b/helm/cluster-openstack/Chart.yaml
@@ -3,7 +3,7 @@ name: cluster-openstack
 description: A helm chart for creating Cluster API clusters with the OpenStack infrastructure provider (CAPO).
 home: https://github.com/thg-ice/cluster-openstack
 type: application
-version: 0.18.0
+version: 0.18.8
 annotations:
   # Keeping this here as removing it prevents existing clusters
   # from being upgraded.

--- a/helm/cluster-openstack/files/kubelet-args
+++ b/helm/cluster-openstack/files/kubelet-args
@@ -1,4 +1,7 @@
 cloud-provider: external
+{{- if (semverCompare "~1.24.0" $.Values.kubernetesVersion) }}
+feature-gates: "ExpandPersistentVolumes=true"
+{{- end }}
 eviction-hard : "memory.available<200Mi"
 eviction-max-pod-grace-period: "60"
 eviction-soft: "memory.available<500Mi"

--- a/helm/cluster-openstack/templates/_helpers.tpl
+++ b/helm/cluster-openstack/templates/_helpers.tpl
@@ -74,7 +74,7 @@ room for such suffix.
 {{- end -}}
 
 {{- define "kubeletExtraArgs" -}}
-{{- .Files.Get "files/kubelet-args" -}}
+{{ tpl (.Files.Get "files/kubelet-args") $ -}}
 {{- end -}}
 
 {{- define "kubeProxyFiles" }}

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -9,10 +9,8 @@ metadata:
     # Let Cluster API clean this resource up.
     helm.sh/resource-policy: keep
 spec:
-  {{- if .Values.rollout.before }}
   rolloutBefore:
-    certificartesExpiryDays: {{ .Values.rollout.certExpiryDays }}
-  {{- end}}
+    certificartesExpiryDays: 14
   kubeadmConfigSpec:
     {{- if .Values.ignition.enable }}
     format: ignition

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -12,7 +12,7 @@ spec:
   {{- if .Values.rollout.before }}
   rolloutBefore:
     certificartesExpiryDays: {{ .Values.rollout.certExpiryDays }}
-  {{- end}}
+  {{- end }}
   kubeadmConfigSpec:
     {{- if .Values.ignition.enable }}
     format: ignition

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -43,6 +43,9 @@ spec:
           encryption-provider-config: /etc/kubernetes/encryption/config.yaml
           feature-gates: {{ .Values.apiServer.featureGates }}
           kubelet-preferred-address-types: "InternalIP"
+          {{- if (semverCompare "~1.24.0" $.Values.kubernetesVersion) }}
+          logtostderr: "true"
+          {{- end }}
           {{- if .Values.oidc.issuerUrl }}
           {{- with .Values.oidc }}
           oidc-issuer-url: {{ .issuerUrl }}
@@ -73,6 +76,9 @@ spec:
           bind-address: "0.0.0.0"
           cloud-provider: external
           feature-gates: {{ .Values.controllerManager.featureGates }}
+          {{- if (semverCompare "~1.24.0" $.Values.kubernetesVersion) }}
+          logtostderr: "true"
+          {{- end }}
           profiling: "false"
       etcd:
         local:

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -9,6 +9,10 @@ metadata:
     # Let Cluster API clean this resource up.
     helm.sh/resource-policy: keep
 spec:
+  {{- if .Values.rollout.before }}
+  rolloutBefore:
+    certificartesExpiryDays: {{ .Values.rollout.certExpiryDays }}
+  {{- end}}
   kubeadmConfigSpec:
     {{- if .Values.ignition.enable }}
     format: ignition

--- a/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
+++ b/helm/cluster-openstack/templates/kubeadm_control_plane.yaml
@@ -9,8 +9,10 @@ metadata:
     # Let Cluster API clean this resource up.
     helm.sh/resource-policy: keep
 spec:
+  {{- if .Values.rollout.before }}
   rolloutBefore:
-    certificartesExpiryDays: 14
+    certificartesExpiryDays: {{ .Values.rollout.certExpiryDays }}
+  {{- end}}
   kubeadmConfigSpec:
     {{- if .Values.ignition.enable }}
     format: ignition

--- a/helm/cluster-openstack/values.schema.json
+++ b/helm/cluster-openstack/values.schema.json
@@ -218,6 +218,17 @@
             "items": {
                 "type": "string"
             }
+        },
+        "rollout": {
+            "type": "object",
+            "properties": {
+                "before": {
+                    "type": "boolean"
+                },
+                "certExpiryDays": {
+                    "type": "integer"
+                }
+            }
         }
     },
     "required": [

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -76,4 +76,4 @@ kubectlImage: {}
 # machine and certificate rotation prior to expiry
 rollout:
   before: false
-  certExpiryDays: 0
+  certExpiryDays: 14

--- a/helm/cluster-openstack/values.yaml
+++ b/helm/cluster-openstack/values.yaml
@@ -72,3 +72,8 @@ nodePools: {}  # Node pools that should exist for the cluster. Each node pool mu
 includeClusterResourceSet: "true"  # must be a string
 # let's use the kubectl image defaults
 kubectlImage: {}
+
+# machine and certificate rotation prior to expiry
+rollout:
+  before: false
+  certExpiryDays: 0


### PR DESCRIPTION
This PR:

- Adds ability to set machine and certificates rotation before expiry.

### Testing

- [ ] Fresh install works.
- [ ] Upgrade from previous version works.

### Checklist

- [ ] Update changelog in `CHANGELOG.md`.
- [ ] Make sure `values.yaml` is valid.
